### PR TITLE
Update `maxFunds` Algorithm to Accept Fixed-Value Targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,15 @@ Note that in the selection process, each UTXO's contribution towards the transac
 
 ### Sending Max Funds
 
-The `maxFunds` algorithm is tailored for situations where the aim is to transfer all funds from available UTXOs to a single recipient address. To utilize this functionality, either directly import and use `maxFunds` or apply `coinselect` by specifying the recipient's address in the `remainder` argument while omitting the `targets`. This approach ensures that all available funds, minus the transaction fees, are sent to the specified recipient address.
+The `maxFunds` algorithm is ideal for transferring all available funds from UTXOs to a specified recipient. To use this algorithm, specify the recipient in the `remainder`. It's also possible to set additional fixed-value targets, if needed.
+
+If the `remainder` value would be below the dust threshold, the function returns `undefined`.
 
 Example:
 ```typescript
-import { coinselect } from '@bitcoinerlab/coinselect';
+import { maxFunds } from '@bitcoinerlab/coinselect';
 
-const { utxos, targets, fee, vsize } = coinselect({
+const { utxos, targets, fee, vsize } = maxFunds({
   utxos: [
     {
       output: new Output({ descriptor: 'addr(bc1qzne9qykh9j55qt8ccqamusp099spdfr49tje60)' }),
@@ -171,12 +173,15 @@ const { utxos, targets, fee, vsize } = coinselect({
       value: 4000
     }
   ],
+  targets: [
+    // Additional fixed-value targets can be included here
+  ],
   remainder: new Output({ descriptor: 'addr(bc1qwfh5mj2kms4rrf8amr66f7d5ckmpdqdzlpr082)' }),
   feeRate: 1.34
 });
 ```
 
-The final recipient value in the transaction will be: `targets[0].value`.
+The value for the recipient (remainder) is determined by subtracting the sum of the values in `targets` and the `fee` from the total value of `utxos`. To access the recipient's value, use `targets[targets.length - 1].value`.
 
 ### Avoid Change
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/coinselect",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/coinselect",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitcoinerlab/coinselect",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "description": "A TypeScript library for Bitcoin transaction management, based on Bitcoin Descriptors for defining inputs and outputs. It facilitates optimal UTXO selection and transaction size calculation.",

--- a/src/algos/maxFunds.ts
+++ b/src/algos/maxFunds.ts
@@ -10,23 +10,26 @@ import { isDust } from '../dust';
 
 /**
  * The `maxFunds` algorithm is tailored for scenarios where the goal is to transfer all funds from specified UTXOs to a single recipient output.
- * To utilize this function, specify the recipient output in the `remainder` argument, while omitting the `targets` parameter.
+ * To utilize this function, specify the recipient output in the `remainder` argument.
  * In this context, the `remainder` serves as the recipient of the funds.
  *
  * Notes:
  *
  * - This function does not reorder UTXOs prior to selection.
  * - UTXOs that do not provide enough value to cover their respective fee contributions are automatically excluded.
+ * - Recipient of all funds is set to last position of the returned `targets` array.
  *
  * Refer to {@link coinselect coinselect} for additional details on input parameters and expected returned values.
  */
 export function maxFunds({
   utxos,
+  targets,
   remainder,
   feeRate,
   dustRelayFeeRate = DUST_RELAY_FEE_RATE
 }: {
   utxos: Array<OutputWithValue>;
+  targets: Array<OutputWithValue>;
   /**
    * Recipient to send maxFunds
    */
@@ -35,14 +38,18 @@ export function maxFunds({
   dustRelayFeeRate?: number;
 }) {
   validateOutputWithValues(utxos);
+  targets.length === 0 || validateOutputWithValues(targets);
   validateFeeRate(feeRate);
   validateFeeRate(dustRelayFeeRate);
+
+  const outputs = [...targets.map(target => target.output), remainder];
+  const targetsValue = targets.reduce((a, target) => a + target.value, 0);
 
   const allUtxosFee = Math.ceil(
     feeRate *
       vsize(
         utxos.map(utxo => utxo.output),
-        [remainder]
+        outputs
       )
   );
 
@@ -50,7 +57,7 @@ export function maxFunds({
   const validUtxos = utxos.filter(validUtxo => {
     const txSizeWithoutUtxo = vsize(
       utxos.filter(utxo => utxo !== validUtxo).map(utxo => utxo.output),
-      [remainder]
+      outputs
     );
     const feeContribution =
       allUtxosFee - Math.ceil(feeRate * txSizeWithoutUtxo);
@@ -62,15 +69,16 @@ export function maxFunds({
     feeRate *
       vsize(
         validUtxos.map(utxo => utxo.output),
-        [remainder]
+        outputs
       )
   );
   const validUtxosValue = validUtxos.reduce((a, utxo) => a + utxo.value, 0);
-  const remainderValue = validUtxosValue - validFee;
+  const remainderValue = validUtxosValue - targetsValue - validFee;
   if (!isDust(remainder, remainderValue, dustRelayFeeRate)) {
     //return the same reference if nothing changed to interact nicely with
     //reactive components
-    const targets = [{ output: remainder, value: remainderValue }];
+    //mutate targets:
+    targets = [...targets, { output: remainder, value: remainderValue }];
     return {
       utxos: utxos.length === validUtxos.length ? utxos : validUtxos,
       targets,

--- a/test/fixtures/maxFunds.json
+++ b/test/fixtures/maxFunds.json
@@ -22,8 +22,7 @@
         {
           "value": 25120
         }
-      ],
-      "fee": 4880
+      ]
     },
     "utxos": [
       {
@@ -36,6 +35,56 @@
       },
       {
         "value": 10000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      }
+    ],
+    "targets": []
+  },
+  {
+    "description": "maxFunds 3 utxos, 1 target",
+    "remainder": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+    "feeRate": 10,
+    "expected": {
+      "inputs": [
+        {
+          "i": 0,
+          "value": 10000
+        },
+        {
+          "i": 1,
+          "value": 10000
+        },
+        {
+          "i": 2,
+          "value": 10000
+        }
+      ],
+      "outputs": [
+        {
+          "value": 1000
+        },
+        {
+          "value": 23780
+        }
+      ]
+    },
+    "utxos": [
+      {
+        "value": 10000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      },
+      {
+        "value": 10000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      },
+      {
+        "value": 10000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      }
+    ],
+    "targets": [
+      {
+        "value": 1000,
         "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
       }
     ]
@@ -44,14 +93,13 @@
     "description": "maxFunds, output is dust (no result)",
     "remainder": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
     "feeRate": 10,
-    "expected": {
-      "fee": 1920
-    },
+    "expected": {},
     "utxos": [
       {
         "value": 2000,
         "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
       }
-    ]
+    ],
+    "targets": []
   }
 ]


### PR DESCRIPTION
This update to the `maxFunds` algorithm in the @bitcoinerlab/coinselect library enhances its functionality by allowing the inclusion of fixed-value targets in addition to the remainder. The change ensures more flexibility in handling scenarios where a combination of specific targets and the maximum possible fund transfer to a recipient is desired.

The README.md and relevant test fixtures have been updated to reflect this change, and the package version has been bumped to 1.1.0 to indicate this significant update.

Key Changes:
- Modified `maxFunds` function signature to include an additional `targets` parameter.
- Updated README.md with new usage examples and descriptions.
- Adjusted test fixtures to cover the updated functionality of `maxFunds`.
- Version bump in package.json and package-lock.json to 1.1.0.

These changes enhance the utility of the `maxFunds` algorithm, aligning it with practical use cases in Bitcoin transaction management.