### PR TITLE
Allow to force the selection of utxos

### DIFF
--- a/src/coinselect.ts
+++ b/src/coinselect.ts
@@ -1,11 +1,6 @@
 //TODO: docs: add a reference to the API
 import type { OutputInstance } from '@bitcoinerlab/descriptors';
-import { OutputWithValue, DUST_RELAY_FEE_RATE } from './index';
-import {
-  validateFeeRate,
-  validateOutputWithValues,
-  validateDust
-} from './validation';
+import { OutputWithValue, DUST_RELAY_FEE_RATE, Input } from './index';
 import { addUntilReach } from './algos/addUntilReach';
 import { avoidChange } from './algos/avoidChange';
 import { isSegwitTx } from './vsize';
@@ -81,7 +76,7 @@ export function coinselect({
    * Array of UTXOs for the transaction. Each UTXO includes an `OutputInstance`
    * and its value.
    */
-  utxos: Array<OutputWithValue>;
+  utxos: Array<Input>;
   /**
    * Array of transaction targets. If specified, `remainder` is used
    * as the change address.
@@ -103,14 +98,6 @@ export function coinselect({
    */
   dustRelayFeeRate?: number;
 }) {
-  validateOutputWithValues(utxos);
-  if (targets) {
-    validateOutputWithValues(targets);
-    validateDust(targets);
-  }
-  validateFeeRate(feeRate);
-  validateFeeRate(dustRelayFeeRate);
-
   //We will assume that the tx is segwit if there is at least one segwit
   //utxo for computing the utxo ordering. This is an approximation.
   //Note that having one segwit utxo does not mean the final tx will be segwit

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,4 @@ export { maxFunds } from './algos/maxFunds';
 export { addUntilReach } from './algos/addUntilReach';
 export { avoidChange } from './algos/avoidChange';
 export type OutputWithValue = { output: OutputInstance; value: number };
+export type Input = OutputWithValue & { forceSelection?: boolean };

--- a/test/fixtures/addUntilReach.json
+++ b/test/fixtures/addUntilReach.json
@@ -180,6 +180,141 @@
     ]
   },
   {
+    "description": "1 output, forcing bigger utxo, change expected",
+    "remainder": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+    "feeRate": 5,
+    "expected": {
+      "inputs": [
+        {
+          "i": 2,
+          "value": 80000
+        }
+      ],
+      "outputs": [
+        {
+          "value": 4700
+        },
+        {
+          "value": 74170
+        }
+      ]
+    },
+    "utxos": [
+      {
+        "value": 10000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      },
+      {
+        "value": 40000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      },
+      {
+        "value": 80000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+        "forceSelection": true
+      }
+    ],
+    "targets": [
+      {
+        "value": 4700,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      }
+    ]
+  },
+  {
+    "description": "1 output, forcing multiple utxos, change expected",
+    "remainder": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+    "feeRate": 5,
+    "expected": {
+      "inputs": [
+        {
+          "i": 0,
+          "value": 10000
+        },
+        {
+          "i": 2,
+          "value": 80000
+        }
+      ],
+      "outputs": [
+        {
+          "value": 4700
+        },
+        {
+          "value": 83430
+        }
+      ]
+    },
+    "utxos": [
+      {
+        "value": 10000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+        "forceSelection": true
+      },
+      {
+        "value": 40000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      },
+      {
+        "value": 80000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+        "forceSelection": true
+      }
+    ],
+    "targets": [
+      {
+        "value": 4700,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      }
+    ]
+  },
+  {
+    "description": "1 output, forcing small utxo, change expected",
+    "remainder": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+    "feeRate": 5,
+    "expected": {
+      "inputs": [
+        {
+          "i": 0,
+          "value": 2000
+        },
+        {
+          "i": 1,
+          "value": 10000
+        }
+      ],
+      "outputs": [
+        {
+          "value": 4700
+        },
+        {
+          "value": 5430
+        }
+      ]
+    },
+    "utxos": [
+      {
+        "value": 2000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+        "forceSelection": true
+      },
+      {
+        "value": 10000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      },
+      {
+        "value": 80000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      }
+    ],
+    "targets": [
+      {
+        "value": 4700,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      }
+    ]
+  },
+  {
     "description": "1 output, fails, skips (and finishes on) detrimental input",
     "remainder": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
     "feeRate": 55,

--- a/test/fixtures/coinselect.json
+++ b/test/fixtures/coinselect.json
@@ -180,6 +180,92 @@
     ]
   },
   {
+    "description": "1 output, forcing utxo, no change",
+    "remainder": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+    "feeRate": 5,
+    "expected": {
+      "inputs": [
+        {
+          "i": 0,
+          "value": 10000
+        }
+      ],
+      "outputs": [
+        {
+          "value": 8400
+        }
+      ]
+    },
+    "utxos": [
+      {
+        "value": 10000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+        "forceSelection": true
+      },
+      {
+        "value": 40000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      },
+      {
+        "value": 40000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      }
+    ],
+    "targets": [
+      {
+        "value": 8400,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      }
+    ]
+  },
+  {
+    "description": "1 output, forcing multiple utxos, change expected",
+    "remainder": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+    "feeRate": 5,
+    "expected": {
+      "inputs": [
+        {
+          "i": 1,
+          "value": 40000
+        },
+        {
+          "i": 2,
+          "value": 40000
+        }
+      ],
+      "outputs": [
+        {
+          "value": 4700
+        },
+        {
+          "value": 73430
+        }
+      ]
+    },
+    "utxos": [
+      {
+        "value": 10000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      },
+      {
+        "value": 40000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+        "forceSelection": true
+      },
+      {
+        "value": 40000,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
+        "forceSelection": true
+      }
+    ],
+    "targets": [
+      {
+        "value": 4700,
+        "descriptor": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)"
+      }
+    ]
+  },
+  {
     "description": "1 output, passes, poor ordering but still good",
     "remainder": "addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)",
     "feeRate": 5,


### PR DESCRIPTION
I added a `forceSelection` property to the `utxos` argument of `coinselect` and the algorithms `addUntilReach` and `avoidChange`. This can be useful if we want to use some base UTXOs and if necessary complete with a selection (e.g. when spending an anchor output). The changes aren't significant, we just need to check before the loop if the forced UTXOs already cover the targets value + fee, in that case we return directly. That duplicates a bit of code so let me know if there is a better way.

Tests are passing, I added some to cover this new behavior. 

Another thing that could be useful in the case of an anchor output spending scenario is to be able to have an empty targets array. In that case, it should just select UTXOs to pay for the fees without any precise targets value. This may be in a follow-up PR.