### PR TITLE
Fix: Allow UTXO with value zero in validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/coinselect",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/coinselect",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^2.1.0"
@@ -742,9 +742,9 @@
       }
     },
     "node_modules/@bitcoinerlab/secp256k1": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/secp256k1/-/secp256k1-1.0.5.tgz",
-      "integrity": "sha512-8gT+ukTCFN2rTxn4hD9Jq3k+UJwcprgYjfK/SQUSLgznXoIgsBnlPuARMkyyuEjycQK9VvnPiejKdszVTflh+w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/secp256k1/-/secp256k1-1.1.1.tgz",
+      "integrity": "sha512-uhjW51WfVLpnHN7+G0saDcM/k9IqcyTbZ+bDgLF3AX8V/a3KXSE9vn7UPBrcdU72tp0J4YPR7BHp2m7MLAZ/1Q==",
       "dependencies": {
         "@noble/hashes": "^1.1.5",
         "@noble/secp256k1": "^1.7.1"
@@ -1351,9 +1351,9 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
-      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
+      "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -6425,9 +6425,9 @@
       }
     },
     "@bitcoinerlab/secp256k1": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/secp256k1/-/secp256k1-1.0.5.tgz",
-      "integrity": "sha512-8gT+ukTCFN2rTxn4hD9Jq3k+UJwcprgYjfK/SQUSLgznXoIgsBnlPuARMkyyuEjycQK9VvnPiejKdszVTflh+w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/secp256k1/-/secp256k1-1.1.1.tgz",
+      "integrity": "sha512-uhjW51WfVLpnHN7+G0saDcM/k9IqcyTbZ+bDgLF3AX8V/a3KXSE9vn7UPBrcdU72tp0J4YPR7BHp2m7MLAZ/1Q==",
       "requires": {
         "@noble/hashes": "^1.1.5",
         "@noble/secp256k1": "^1.7.1"
@@ -6887,9 +6887,9 @@
       }
     },
     "@scure/base": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
-      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
+      "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitcoinerlab/coinselect",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "description": "A TypeScript library for Bitcoin transaction management, based on Bitcoin Descriptors for defining inputs and outputs. It facilitates optimal UTXO selection and transaction size calculation.",

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -7,7 +7,8 @@ export function validateOutputWithValues(
   if (outputAndValues.length === 0) throw new Error('Empty group');
   for (const outputAndValue of outputAndValues) {
     const value = outputAndValue.value;
-    if (!Number.isInteger(value) || value <= 0 || value > 1e14 /*1 M Btc*/) {
+    //note an utxo with value === 0 is possible, see https://blockstream.info/testnet/tx/a063dbdc23cf969df020536f75c431167a2bbf29d6215a2067495ac46991c954
+    if (!Number.isInteger(value) || value < 0 || value > 1e14 /*1 M Btc*/) {
       throw new Error(`Input value ${value} not supported`);
     }
   }


### PR DESCRIPTION
### Summary

This PR addresses an issue with the UTXO validation logic. The current implementation incorrectly assumes that a UTXO cannot have a value of zero, which can lead to unexpected behaviors. This update modifies the validation function to correctly handle UTXOs with a value of zero.

### Changes
- Updated validation logic in `src/validation.ts` to allow UTXOs with a value of zero.
- Bumped the version in `package.json` from 1.2.0 to 1.2.1.

### Reference
- [Blockstream Info Transaction](https://blockstream.info/testnet/tx/a063dbdc23cf969df020536f75c431167a2bbf29d6215a2067495ac46991c954)
