### PR TITLE
Add support for single-key tr(KEY) and addr(TAPROOT_ADDRESS) descriptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/**/*.d.ts
 dist/
 docs/
 webdocs/
+.aider*

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This code produces the following result:
 
 **Note on No Solutions:** If `coinselect` and similar algorithms in this library can't find a feasible combination of UTXOs for the specified targets, they return `undefined`. This means the transaction isn't viable with the given inputs and constraints. Ensure to handle such cases in your code, perhaps by informing the user or modifying the input parameters.
 
-**Note on `addr()`:** When using `addr(SH_ADDRESS)` descriptors, the library assumes they represent Segwit `SH_WPKH_ADDRESS`. For scripts, use the `sh(MINISCRIPT)` descriptor format.
+**Note on `addr()`:** When using `addr(SH_ADDRESS)` descriptors, the library assumes they represent Segwit `SH_WPKH_ADDRESS`. For scripts, use the `sh(MINISCRIPT)` descriptor format. Similarly, when using `addr(TR_ADDRESS)` descriptors, the library assumes they represent single-key Taproot addresses such as those defined in BIP86, without script paths.
 
 Additionally, if you only need to compute the `vsize` for a specific set of inputs and outputs, you can use the following approach:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bitcoinerlab/coinselect",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/coinselect",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@bitcoinerlab/descriptors": "^2.2.1"
+        "@bitcoinerlab/descriptors": "^2.3.0"
       },
       "devDependencies": {
         "@bitcoinerlab/configs": "github:bitcoinerlab/configs",
@@ -712,9 +712,9 @@
       }
     },
     "node_modules/@bitcoinerlab/descriptors": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.2.1.tgz",
-      "integrity": "sha512-mQ10+2CgFxpTjetLZvWCELd59gCHCI1DIiHMKHODaXogEzRYi48ANxuXiUdk6XErcxnsDKVZf9788uVQCSevrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.3.0.tgz",
+      "integrity": "sha512-xRLF8dE7RdfrhPjRigj3mhOZcojGhTx8DB87oWYE8yzPHRR6Ow5HDECBynLFp/5Idf7m2vifNK7SI/cCu8nuaQ==",
       "dependencies": {
         "@bitcoinerlab/miniscript": "^1.4.0",
         "@bitcoinerlab/secp256k1": "^1.2.0",
@@ -1273,11 +1273,11 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
-      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
       "dependencies": {
-        "@noble/hashes": "1.6.0"
+        "@noble/hashes": "1.7.1"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
-      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1353,9 +1353,9 @@
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
-      "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -1950,9 +1950,9 @@
       "dev": true
     },
     "node_modules/base-x": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="
     },
     "node_modules/bech32": {
       "version": "2.0.0",
@@ -2008,9 +2008,9 @@
       }
     },
     "node_modules/bitcoinjs-lib": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.5.tgz",
-      "integrity": "sha512-yuf6xs9QX/E8LWE2aMJPNd0IxGofwfuVOiYdNUESkc+2bHHVKjhJd8qewqapeoolh9fihzHGoDCB5Vkr57RZCQ==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
+      "integrity": "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bech32": "^2.0.0",
@@ -5759,9 +5759,9 @@
       }
     },
     "node_modules/wif/node_modules/base-x": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
-      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -6405,9 +6405,9 @@
       }
     },
     "@bitcoinerlab/descriptors": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.2.1.tgz",
-      "integrity": "sha512-mQ10+2CgFxpTjetLZvWCELd59gCHCI1DIiHMKHODaXogEzRYi48ANxuXiUdk6XErcxnsDKVZf9788uVQCSevrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@bitcoinerlab/descriptors/-/descriptors-2.3.0.tgz",
+      "integrity": "sha512-xRLF8dE7RdfrhPjRigj3mhOZcojGhTx8DB87oWYE8yzPHRR6Ow5HDECBynLFp/5Idf7m2vifNK7SI/cCu8nuaQ==",
       "requires": {
         "@bitcoinerlab/miniscript": "^1.4.0",
         "@bitcoinerlab/secp256k1": "^1.2.0",
@@ -6838,17 +6838,17 @@
       }
     },
     "@noble/curves": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
-      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
       "requires": {
-        "@noble/hashes": "1.6.0"
+        "@noble/hashes": "1.7.1"
       }
     },
     "@noble/hashes": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
-      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6891,9 +6891,9 @@
       }
     },
     "@scure/base": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
-      "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="
     },
     "@sinclair/typebox": {
       "version": "0.27.8",
@@ -7334,9 +7334,9 @@
       "dev": true
     },
     "base-x": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="
     },
     "bech32": {
       "version": "2.0.0",
@@ -7380,9 +7380,9 @@
       "integrity": "sha512-O1htyufFTYy3EO0JkHg2CLykdXEtV2ssqw47Gq9A0WByp662xpJnMEB9m43LZjsSDjIAOozWRExlFQk2hlV1XQ=="
     },
     "bitcoinjs-lib": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.5.tgz",
-      "integrity": "sha512-yuf6xs9QX/E8LWE2aMJPNd0IxGofwfuVOiYdNUESkc+2bHHVKjhJd8qewqapeoolh9fihzHGoDCB5Vkr57RZCQ==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.1.7.tgz",
+      "integrity": "sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==",
       "requires": {
         "@noble/hashes": "^1.2.0",
         "bech32": "^2.0.0",
@@ -10079,9 +10079,9 @@
       },
       "dependencies": {
         "base-x": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
-          "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+          "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
           "requires": {
             "safe-buffer": "^5.0.1"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitcoinerlab/coinselect",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "description": "A TypeScript library for Bitcoin transaction management, based on Bitcoin Descriptors for defining inputs and outputs. It facilitates optimal UTXO selection and transaction size calculation.",
@@ -52,6 +52,6 @@
     "regtest-client": "^0.2.1"
   },
   "dependencies": {
-    "@bitcoinerlab/descriptors": "^2.2.1"
+    "@bitcoinerlab/descriptors": "^2.3.0"
   }
 }

--- a/src/vsize.ts
+++ b/src/vsize.ts
@@ -26,6 +26,7 @@ export const isSegwitTx = (inputs: Array<OutputInstance>) =>
  * (Script Hash-Witness Public Key Hash).
  * For inputs using arbitrary scripts (not standard addresses),
  * use a descriptor in the format `sh(MINISCRIPT)`.
+ * Similarly, add(TR_TYPE_ADDRESS) is assumed to be a single-key tr address.
  *
  * @example
  * ```

--- a/test/tools/vsize/combine.ts
+++ b/test/tools/vsize/combine.ts
@@ -69,6 +69,14 @@ const outputsData: OutputsDataType = {
       keyPath: '/0/0'
     })
   },
+  trSingleKey: {
+    descriptor: scriptExpressions.trBIP32({
+      masterNode,
+      network,
+      account: 0,
+      keyPath: '/0/0'
+    })
+  },
   shWpkh: {
     descriptor: scriptExpressions.shWpkhBIP32({
       masterNode,
@@ -135,6 +143,7 @@ const outputKeys = [
   'pkh',
   'wpkh',
   'shWpkh',
+  'trSingleKey',
   'wshDelayed',
   'shInstant',
   'shWshDelayed'

--- a/test/vsize.test.ts
+++ b/test/vsize.test.ts
@@ -80,7 +80,7 @@ describe('vsize', () => {
         // Check if the fixture size using signatures is exactly the
         // same as the signed one:
         if (txSize !== expectedSize)
-          console.error(psbt.extractTransaction().toHex());
+          console.error({ info, txSize, expectedSize, psbt: psbt.toHex() });
         expect(txSize).toBe(expectedSize);
 
         // Check if the best guess fixture size is within the expected range:


### PR DESCRIPTION
Add support for single-key tr(KEY) and addr(TAPROOT_ADDRESS) descriptors
This PR updates the dependency to @bitcoinerlab/descriptors v2.3.0, which adds support for:
 - Single-key Taproot descriptors using the tr(KEY) format
 - Taproot addresses using addr(TAPROOT_ADDRESS) format
Changes:
 - Updated the package dependency to use the latest version with Taproot support
 - Updated tests to work with the new Taproot functionality
 - Ensured compatibility with the new descriptor formats

This enhancement allows our coin selection library to work with the latest Bitcoin transaction types, including Taproot outputs created from either raw public keys or Taproot addresses.