### PR TITLE
Prevent crash in dustThreshold for addr() descriptors lacking miniscript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/coinselect",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/coinselect",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitcoinerlab/coinselect",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "description": "A TypeScript library for Bitcoin transaction management, based on Bitcoin Descriptors for defining inputs and outputs. It facilitates optimal UTXO selection and transaction size calculation.",


### PR DESCRIPTION
Prevent crash in dustThreshold for addr() descriptors lacking miniscript:

- Wrap inputWeight call in try/catch to handle outputs (e.g., WSH) without miniscript.
- Fallback to a conservative estimate of 272 weight units (typical P2WPKH input) when input weight cannot be computed.
- Ensures dustThreshold calculation remains safe and consistent with Bitcoin Core Wallet behavior.
- Bump version to 1.3.1.