### PR TITLE
feat: reflect utxos immutability in types

### DIFF
--- a/src/algos/addUntilReach.ts
+++ b/src/algos/addUntilReach.ts
@@ -22,14 +22,14 @@ import { isDust } from '../dust';
  *
  * Refer to {@link coinselect coinselect} for additional details on input parameters and expected returned values.
  */
-export function addUntilReach({
+export function addUntilReach<Utxo extends OutputWithValue>({
   utxos,
   targets,
   remainder,
   feeRate,
   dustRelayFeeRate = DUST_RELAY_FEE_RATE
 }: {
-  utxos: Array<OutputWithValue>;
+  utxos: Array<Utxo>;
   targets: Array<OutputWithValue>;
   remainder: OutputInstance;
   feeRate: number;
@@ -42,7 +42,7 @@ export function addUntilReach({
   validateFeeRate(dustRelayFeeRate);
 
   const targetsValue = targets.reduce((a, target) => a + target.value, 0);
-  const utxosSoFar: Array<OutputWithValue> = [];
+  const utxosSoFar: Array<Utxo> = [];
 
   for (const candidate of utxos) {
     const txSizeSoFar = vsize(

--- a/src/algos/avoidChange.ts
+++ b/src/algos/avoidChange.ts
@@ -23,14 +23,14 @@ import { isDust } from '../dust';
  *
  * Refer to {@link coinselect coinselect} for additional details on input parameters and expected returned values.
  */
-export function avoidChange({
+export function avoidChange<Utxo extends OutputWithValue>({
   utxos,
   targets,
   remainder,
   feeRate,
   dustRelayFeeRate = DUST_RELAY_FEE_RATE
 }: {
-  utxos: Array<OutputWithValue>;
+  utxos: Array<Utxo>;
   targets: Array<OutputWithValue>;
   /**
    * This is the hypotetical change that this algo will check it would
@@ -47,7 +47,7 @@ export function avoidChange({
   validateFeeRate(dustRelayFeeRate);
 
   const targetsValue = targets.reduce((a, target) => a + target.value, 0);
-  const utxosSoFar: Array<OutputWithValue> = [];
+  const utxosSoFar: Array<Utxo> = [];
 
   for (const candidate of utxos) {
     const utxosSoFarValue = utxosSoFar.reduce((a, utxo) => a + utxo.value, 0);

--- a/src/algos/maxFunds.ts
+++ b/src/algos/maxFunds.ts
@@ -22,14 +22,14 @@ import { isDust } from '../dust';
  *
  * Refer to {@link coinselect coinselect} for additional details on input parameters and expected returned values.
  */
-export function maxFunds({
+export function maxFunds<Utxo extends OutputWithValue>({
   utxos,
   targets,
   remainder,
   feeRate,
   dustRelayFeeRate = DUST_RELAY_FEE_RATE
 }: {
-  utxos: Array<OutputWithValue>;
+  utxos: Array<Utxo>;
   targets: Array<OutputWithValue>;
   /**
    * Recipient to send maxFunds

--- a/src/coinselect.ts
+++ b/src/coinselect.ts
@@ -70,7 +70,7 @@ function utxoTransferredValue(
  *
  * @see {@link https://bitcoinerlab.com/modules/descriptors} for descriptor info.
  */
-export function coinselect({
+export function coinselect<Utxo extends OutputWithValue>({
   utxos,
   targets,
   remainder,
@@ -81,7 +81,7 @@ export function coinselect({
    * Array of UTXOs for the transaction. Each UTXO includes an `OutputInstance`
    * and its value.
    */
-  utxos: Array<OutputWithValue>;
+  utxos: Array<Utxo>;
   /**
    * Array of transaction targets. If specified, `remainder` is used
    * as the change address.


### PR DESCRIPTION
As per the documentation, "This library adheres to Immutability principles [...] Returned utxos and targets retain their original references unless they are modified (e.g., removal of utxos or addition of change in targets)". I made the input `utxos` type generic so the selected utxos that are returned are of the same type. This is very useful when you attach additional properties to utxos to be used for signing for example.   