### PR TITLE
Support fractional minimum fee rate (0.1 sat/vB)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/coinselect",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/coinselect",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitcoinerlab/coinselect",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "description": "A TypeScript library for Bitcoin transaction management, based on Bitcoin Descriptors for defining inputs and outputs. It facilitates optimal UTXO selection and transaction size calculation.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 export const DUST_RELAY_FEE_RATE = 3;
 //10 times larger than 2017 peak
 export const MAX_FEE_RATE = 10000;
+export const MIN_FEE_RATE = 0.1;
 
 import type { OutputInstance } from '@bitcoinerlab/descriptors';
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,4 +1,9 @@
-import { OutputWithValue, MAX_FEE_RATE, DUST_RELAY_FEE_RATE } from './index';
+import {
+  OutputWithValue,
+  MIN_FEE_RATE,
+  MAX_FEE_RATE,
+  DUST_RELAY_FEE_RATE
+} from './index';
 import { vsize } from './vsize';
 import { isDust } from './dust';
 export function validateOutputWithValues(
@@ -14,7 +19,11 @@ export function validateOutputWithValues(
   }
 }
 export function validateFeeRate(feeRate: number) {
-  if (!Number.isFinite(feeRate) || feeRate < 1 || feeRate > MAX_FEE_RATE) {
+  if (
+    !Number.isFinite(feeRate) ||
+    feeRate < MIN_FEE_RATE ||
+    feeRate > MAX_FEE_RATE
+  ) {
     throw new Error(`Fee rate ${feeRate} not supported`);
   }
 }


### PR DESCRIPTION
This PR updates the library to support the new default minimum relay fee introduced in Bitcoin Core (0.1 sat/vB). Previously, the code enforced a minimum of 1 sat/vB, which is no longer consistent with current network policy.