### PR TITLE
Allow configurable minimum fee-rate validation for TRUC txs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ For a more detailed explanation, refer to [the API documentation](https://bitcoi
 
 #### Fee Rates and Virtual Size
 
+By default, `feeRate` is validated against a minimum of `0.1` sat/vB. For TRUC
+transactions, you can lower that validation floor by passing `minimumFeeRate`:
+
+```typescript
+const selected = coinselect({
+  utxos,
+  targets,
+  remainder,
+  feeRate: 0,
+  minimumFeeRate: 0
+});
+```
+
 The rate (`fee / vsize`) returned by `coinselect` may be higher than the specified `feeRate`. This discrepancy is due to rounding effects (target values are integer satoshis represented as `bigint`) and the possibility of not creating change if it falls below the dust threshold, as illustrated in the first code snippet.
 
 After signing, the final `vsize` might be lower than the initial estimate provided by `coinselect()`/`vsize()`. This is because `vsize` is calculated assuming DER-encoded signatures of 72 bytes, though they can occasionally be 71 bytes. Consequently, the final `feeRate` might exceed the pre-signing estimate. In summary, `feeRateAfterSigning >= (fee / vsize) >= feeRate`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitcoinerlab/coinselect",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitcoinerlab/coinselect",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/descriptors": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitcoinerlab/coinselect",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Jose-Luis Landabaso",
   "license": "MIT",
   "description": "A TypeScript library for Bitcoin transaction management, based on Bitcoin Descriptors for defining inputs and outputs. It facilitates optimal UTXO selection and transaction size calculation.",

--- a/src/algos/addUntilReach.ts
+++ b/src/algos/addUntilReach.ts
@@ -1,5 +1,5 @@
 import type { OutputInstance } from '@bitcoinerlab/descriptors';
-import { DUST_RELAY_FEE_RATE, OutputWithValue } from '../index';
+import { DUST_RELAY_FEE_RATE, MIN_FEE_RATE, OutputWithValue } from '../index';
 import {
   validateFeeRate,
   validateOutputWithValues,
@@ -27,18 +27,20 @@ export function addUntilReach({
   targets,
   remainder,
   feeRate,
+  minimumFeeRate = MIN_FEE_RATE,
   dustRelayFeeRate = DUST_RELAY_FEE_RATE
 }: {
   utxos: Array<OutputWithValue>;
   targets: Array<OutputWithValue>;
   remainder: OutputInstance;
   feeRate: number;
+  minimumFeeRate?: number;
   dustRelayFeeRate?: number;
 }) {
   validateOutputWithValues(utxos);
   validateOutputWithValues(targets);
   validateDust(targets);
-  validateFeeRate(feeRate);
+  validateFeeRate(feeRate, minimumFeeRate);
   validateFeeRate(dustRelayFeeRate);
 
   const targetsValue = targets.reduce((a, target) => a + target.value, 0n);
@@ -96,7 +98,12 @@ export function addUntilReach({
         return {
           utxos: utxosResult.length === utxos.length ? utxos : utxosResult,
           targets: targetsResult,
-          ...validatedFeeAndVsize(utxosResult, targetsResult, feeRate)
+          ...validatedFeeAndVsize(
+            utxosResult,
+            targetsResult,
+            feeRate,
+            minimumFeeRate
+          )
         };
       } else {
         utxosSoFar.push(candidate);

--- a/src/algos/avoidChange.ts
+++ b/src/algos/avoidChange.ts
@@ -1,5 +1,5 @@
 import type { OutputInstance } from '@bitcoinerlab/descriptors';
-import { DUST_RELAY_FEE_RATE, OutputWithValue } from '../index';
+import { DUST_RELAY_FEE_RATE, MIN_FEE_RATE, OutputWithValue } from '../index';
 import {
   validateFeeRate,
   validateOutputWithValues,
@@ -28,6 +28,7 @@ export function avoidChange({
   targets,
   remainder,
   feeRate,
+  minimumFeeRate = MIN_FEE_RATE,
   dustRelayFeeRate = DUST_RELAY_FEE_RATE
 }: {
   utxos: Array<OutputWithValue>;
@@ -38,12 +39,13 @@ export function avoidChange({
    */
   remainder: OutputInstance;
   feeRate: number;
+  minimumFeeRate?: number;
   dustRelayFeeRate?: number;
 }) {
   validateOutputWithValues(utxos);
   validateOutputWithValues(targets);
   validateDust(targets);
-  validateFeeRate(feeRate);
+  validateFeeRate(feeRate, minimumFeeRate);
   validateFeeRate(dustRelayFeeRate);
 
   const targetsValue = targets.reduce((a, target) => a + target.value, 0n);
@@ -95,7 +97,12 @@ export function avoidChange({
           return {
             utxos: utxosResult.length === utxos.length ? utxos : utxosResult,
             targets,
-            ...validatedFeeAndVsize(utxosResult, targets, feeRate)
+            ...validatedFeeAndVsize(
+              utxosResult,
+              targets,
+              feeRate,
+              minimumFeeRate
+            )
           };
         } else utxosSoFar.push(candidate);
       }

--- a/src/algos/maxFunds.ts
+++ b/src/algos/maxFunds.ts
@@ -1,5 +1,5 @@
 import type { OutputInstance } from '@bitcoinerlab/descriptors';
-import { DUST_RELAY_FEE_RATE, OutputWithValue } from '../index';
+import { DUST_RELAY_FEE_RATE, MIN_FEE_RATE, OutputWithValue } from '../index';
 import {
   validateFeeRate,
   validateOutputWithValues,
@@ -27,6 +27,7 @@ export function maxFunds({
   targets,
   remainder,
   feeRate,
+  minimumFeeRate = MIN_FEE_RATE,
   dustRelayFeeRate = DUST_RELAY_FEE_RATE
 }: {
   utxos: Array<OutputWithValue>;
@@ -36,12 +37,13 @@ export function maxFunds({
    */
   remainder: OutputInstance;
   feeRate: number;
+  minimumFeeRate?: number;
   dustRelayFeeRate?: number;
 }) {
   validateOutputWithValues(utxos);
   if (targets.length) validateOutputWithValues(targets);
   validateDust(targets);
-  validateFeeRate(feeRate);
+  validateFeeRate(feeRate, minimumFeeRate);
   validateFeeRate(dustRelayFeeRate);
 
   const outputs = [...targets.map(target => target.output), remainder];
@@ -88,7 +90,7 @@ export function maxFunds({
     return {
       utxos: utxos.length === validUtxos.length ? utxos : validUtxos,
       targets,
-      ...validatedFeeAndVsize(validUtxos, targets, feeRate)
+      ...validatedFeeAndVsize(validUtxos, targets, feeRate, minimumFeeRate)
     };
   } else return;
 }

--- a/src/coinselect.ts
+++ b/src/coinselect.ts
@@ -1,6 +1,6 @@
 //TODO: docs: add a reference to the API
 import type { OutputInstance } from '@bitcoinerlab/descriptors';
-import { OutputWithValue, DUST_RELAY_FEE_RATE } from './index';
+import { OutputWithValue, DUST_RELAY_FEE_RATE, MIN_FEE_RATE } from './index';
 import {
   validateFeeRate,
   validateOutputWithValues,
@@ -75,6 +75,7 @@ export function coinselect({
   targets,
   remainder,
   feeRate,
+  minimumFeeRate = MIN_FEE_RATE,
   dustRelayFeeRate = DUST_RELAY_FEE_RATE
 }: {
   /**
@@ -97,6 +98,12 @@ export function coinselect({
    */
   feeRate: number;
   /**
+   * Minimum fee rate accepted for transaction fee validation. Defaults to the
+   * standard relay floor and can be lowered for package relay use cases.
+   * @defaultValue 0.1
+   */
+  minimumFeeRate?: number;
+  /**
    * Fee rate used to calculate the dust threshold for transaction
    * outputs. Defaults to standard dust relay fee rate if not specified.
    * @defaultValue 3
@@ -108,7 +115,7 @@ export function coinselect({
     validateOutputWithValues(targets);
     validateDust(targets);
   }
-  validateFeeRate(feeRate);
+  validateFeeRate(feeRate, minimumFeeRate);
   validateFeeRate(dustRelayFeeRate);
 
   //We will assume that the tx is segwit if there is at least one segwit
@@ -130,6 +137,7 @@ export function coinselect({
       targets,
       remainder,
       feeRate,
+      minimumFeeRate,
       dustRelayFeeRate
     }) ||
     addUntilReach({
@@ -137,6 +145,7 @@ export function coinselect({
       targets,
       remainder,
       feeRate,
+      minimumFeeRate,
       dustRelayFeeRate
     });
   if (coinselected) {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -22,13 +22,27 @@ export function validateOutputWithValues(
     }
   }
 }
-export function validateFeeRate(feeRate: number) {
+export function validateFeeRate(
+  feeRate: number,
+  minimumFeeRate: number = MIN_FEE_RATE
+) {
+  validateMinimumFeeRate(minimumFeeRate);
   if (
     !Number.isFinite(feeRate) ||
-    feeRate < MIN_FEE_RATE ||
+    feeRate < minimumFeeRate ||
     feeRate > MAX_FEE_RATE
   ) {
     throw new Error(`Fee rate ${feeRate} not supported`);
+  }
+}
+
+function validateMinimumFeeRate(minimumFeeRate: number) {
+  if (
+    !Number.isFinite(minimumFeeRate) ||
+    minimumFeeRate < 0 ||
+    minimumFeeRate > MAX_FEE_RATE
+  ) {
+    throw new Error(`Minimum fee rate ${minimumFeeRate} not supported`);
   }
 }
 
@@ -43,7 +57,8 @@ export function validateDust(
 export function validatedFeeAndVsize(
   utxos: Array<OutputWithValue>,
   targets: Array<OutputWithValue>,
-  feeRate: number
+  feeRate: number,
+  minimumFeeRate: number = MIN_FEE_RATE
 ): { fee: bigint; vsize: number } {
   const fee =
     utxos.reduce((a, u) => a + u.value, 0n) -
@@ -60,6 +75,6 @@ export function validatedFeeAndVsize(
   // Instead, compare final fee
   if (fee < requiredFee)
     throw new Error(`Final fee ${fee} lower than required ${requiredFee}`);
-  validateFeeRate(finalFeeRate);
+  validateFeeRate(finalFeeRate, minimumFeeRate);
   return { fee, vsize: vsizeResult };
 }

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,9 +1,14 @@
 import * as secp256k1 from '@bitcoinerlab/secp256k1';
 import { DescriptorsFactory } from '@bitcoinerlab/descriptors';
 const { Output } = DescriptorsFactory(secp256k1);
-import { coinselect } from '../dist';
+import { addUntilReach, avoidChange, coinselect, maxFunds } from '../dist';
 
 const descriptor = 'addr(12higDjoCCNXSA95xZMWUdPvXNmkAduhWv)';
+
+function output() {
+  return new Output({ descriptor });
+}
+
 describe('errors', () => {
   test('dusty outputs', () => {
     expect(() =>
@@ -34,5 +39,84 @@ describe('errors', () => {
         feeRate: 1
       })
     ).toThrow('Empty group');
+  });
+
+  test('rejects fee rates below the default minimum', () => {
+    expect(() =>
+      coinselect({
+        utxos: [{ output: output(), value: 1000n }],
+        targets: [{ output: output(), value: 1000n }],
+        remainder: output(),
+        feeRate: 0
+      })
+    ).toThrow('Fee rate 0 not supported');
+  });
+
+  test('rejects invalid minimum fee rates', () => {
+    expect(() =>
+      coinselect({
+        utxos: [{ output: output(), value: 1000n }],
+        targets: [{ output: output(), value: 1000n }],
+        remainder: output(),
+        feeRate: 0,
+        minimumFeeRate: -1
+      })
+    ).toThrow('Minimum fee rate -1 not supported');
+  });
+
+  test('allows zero fee rate when minimumFeeRate is zero', () => {
+    const coinselected = coinselect({
+      utxos: [{ output: output(), value: 1000n }],
+      targets: [{ output: output(), value: 1000n }],
+      remainder: output(),
+      feeRate: 0,
+      minimumFeeRate: 0
+    });
+    expect(coinselected).toBeDefined();
+    expect(coinselected?.fee).toBe(0n);
+  });
+
+  test('allows fractional fee rates below 0.1 when minimumFeeRate is lowered', () => {
+    const coinselected = coinselect({
+      utxos: [{ output: output(), value: 2000n }],
+      targets: [{ output: output(), value: 1998n }],
+      remainder: output(),
+      feeRate: 0.01,
+      minimumFeeRate: 0.01
+    });
+    expect(coinselected).toBeDefined();
+    expect(coinselected?.fee).toBe(2n);
+  });
+
+  test('allows zero fee rate in all public selection entry points', () => {
+    expect(
+      addUntilReach({
+        utxos: [{ output: output(), value: 1000n }],
+        targets: [{ output: output(), value: 1000n }],
+        remainder: output(),
+        feeRate: 0,
+        minimumFeeRate: 0
+      })?.fee
+    ).toBe(0n);
+
+    expect(
+      avoidChange({
+        utxos: [{ output: output(), value: 1000n }],
+        targets: [{ output: output(), value: 1000n }],
+        remainder: output(),
+        feeRate: 0,
+        minimumFeeRate: 0
+      })?.fee
+    ).toBe(0n);
+
+    expect(
+      maxFunds({
+        utxos: [{ output: output(), value: 1000n }],
+        targets: [],
+        remainder: output(),
+        feeRate: 0,
+        minimumFeeRate: 0
+      })?.fee
+    ).toBe(0n);
   });
 });


### PR DESCRIPTION
- add an optional `minimumFeeRate` parameter to `coinselect`, `addUntilReach`, `avoidChange`, and `maxFunds`
- keep the default minimum at `0.1` sat/vB for backwards compatibility, while allowing zero or sub-`0.1` fee rates for TRUC/package relay use cases
- add runtime tests for the default rejection path and the lowered-floor acceptance path@ and bump the package version to `2.0.1`
